### PR TITLE
use absolute path for lib

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,10 +1,12 @@
 #!/bin/sh
 
+INCLUDE=`readlink -f ./local/lib/perl5`
+
 cat << EOF
 ---
 addons:
 config_vars:
   PATH: local/bin:/usr/local/bin:/usr/bin:/bin
 default_process_types:
-  web: perl -Mlib=./local/lib/perl5 ./local/bin/starman --preload-app --port \$PORT
+  web: perl -Mlib=${INCLUDE} ./local/bin/starman --preload-app --port \$PORT
 EOF


### PR DESCRIPTION
Using relative path will broken module finding like below

chdir /somewhere;
require Foo.pm;

The code is bad, but it might happen.
I found the issue when using Catalyst::View::Xslate and Text::Xslate. File::Find::find without disabling chdir of the former will cause the latter throw "Can't locate Mouse.pm" error. 
