### PR TITLE
Starman unable to find Plack::Runner with $PWD fix

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -6,5 +6,5 @@ addons:
 config_vars:
   PATH: local/bin:/usr/local/bin:/usr/bin:/bin
 default_process_types:
-  web: perl -Mlib=./local/lib/perl5 ./local/bin/starman --preload-app --port \$PORT
+  web: perl -Mlib=\$PWD/local/lib/perl5 ./local/bin/starman --preload-app --port \$PORT
 EOF


### PR DESCRIPTION
It appears that since the $PWD fix, the local/lib/perl5 directory is no longer included in @INC and starman can not find its modules:

```
2013-04-04T12:44:57+00:00 app[web.1]: BEGIN failed--compilation aborted at ./local/bin/starman line 6.
2013-04-04T12:44:57+00:00 app[web.1]: Can't locate Plack/Runner.pm in @INC (@INC contains: /app/tmp/repo.git/local/lib/perl5 /etc/perl /usr/local/lib/perl/5.10.1 /usr/local/share/perl/5.10.1 /usr/lib/perl5 /usr/share/perl5 /usr/lib/perl/5.10 /usr/share/perl/5.10 /usr/local/lib/site_perl .) at ./local/bin/starman line 6.
```

The log shows that the local/lib/perl5 directory is not in @INC, however the /app/tmp/repo.git... directory is, which does not exist. I believe the $PWD is pointing to the temporary directory for the git push, and not where the application is being installed.

Running `heroku ps` shows the application crashed and the command used to start it:

```
=== web (1X): `perl -Mlib=/app/tmp/repo.git/local/lib/perl5 ./local/bin/starman --preload-app --port $PORT`
web.1: crashed 2013/04/04 08:51:12 (~ 2m ago)
```
