### PR TITLE
Carton support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-Heroku buildpack: Perl
-======================
+# Heroku buildpack: Perl
 
 This is a Heroku buildpack for Perl. It installs dependencies with Carton, then runs any PSGI based web applications using Starman.
 
-Usage
------
+## Usage
 
 Example usage:
 
@@ -32,8 +30,17 @@ Example usage:
 
 The buildpack will detect that your app has an `app.psgi` in the root.
 
-Libraries
----------
+## Libraries
 
 Dependencies can be declared using `cpanfile` and frozen with `carton install`. The buildpack will install these dependencies using [Carton](https://metacpan.org/release/carton) into a cached `./local` directory.
+
+## Perl Version
+
+Perl versions can be specified with `.perl-version` file a la plenv.
+
+    $ echo 5.16.3 > .perl-version
+    $ git add .perl-version
+    $ git commit -m 'use 5.16.3'
+
+Available perl versions are the latest of each stable release, i.e. `5.8.9`, `5.10.1`, `5.12.5`, `5.14.4`, `5.16.3` and `5.18.0`.
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Example usage:
     requires 'DBI', '1.6';
 
     $ carton install
-    $ git add carton.lock
-    $ git commit -m 'bundle carton.lock'
+    $ git add cpanfile.snapshot
+    $ git commit -m 'bundle cpanfile.snapshot'
 
     $ heroku create --stack cedar --buildpack https://github.com/miyagawa/heroku-buildpack-perl.git#carton
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Heroku buildpack: Perl
 ======================
 
-This is a Heroku buildpack that runs any PSGI based web applications using Starman.
+This is a Heroku buildpack for Perl. It installs dependencies with Carton, then runs any PSGI based web applications using Starman.
 
 Usage
 -----
@@ -17,19 +17,23 @@ Example usage:
     requires 'Plack', '1.0000';
     requires 'DBI', '1.6';
 
-    $ heroku create --stack cedar --buildpack https://github.com/miyagawa/heroku-buildpack-perl.git
+    $ carton install
+    $ git add carton.lock
+    $ git commit -m 'bundle carton.lock'
+
+    $ heroku create --stack cedar --buildpack https://github.com/miyagawa/heroku-buildpack-perl.git#carton
 
     $ git push heroku master
     ...
     -----> Heroku receiving push
     -----> Fetching custom buildpack
     -----> Perl/PSGI app detected
-    -----> Installing dependencies
+    -----> Installing dependencies with Carton
 
 The buildpack will detect that your app has an `app.psgi` in the root.
 
 Libraries
 ---------
 
-Dependencies can be declared using `cpanfile` (recommended) or more traditional `Makefile.PL`, `Build.PL` and `META.json` (whichever you can install with `cpanm --installdeps`), and the buildpack will install these dependencies using [cpanm](http://cpanmin.us) into `./local` directory.
+Dependencies can be declared using `cpanfile` and frozen with `carton install`. The buildpack will install these dependencies using [Carton](https://metacpan.org/release/carton) into a cached `./local` directory.
 

--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ if ! [ -e $BUILD_DIR/local/bin/cpanm ]; then
 fi
 
 echo "-----> Installing Carton"
-cpanm --dev Carton
+cpanm --dev Carton 2>&1 | indent
 
 echo "-----> Installing dependencies with Carton"
 carton install --deployment 2>&1 | indent

--- a/bin/compile
+++ b/bin/compile
@@ -4,6 +4,15 @@ indent() {
   sed -u 's/^/       /'
 }
 
+# because vendored perl is relocatable, shebang is not always correct
+# https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/38
+fixin_shebang() {
+  for script in $BUILD_DIR/local/bin/*
+  do
+    perl -i -nle 's{^#!.*perl\s*$}{#!/usr/bin/env perl} unless $head++; print' $script
+  done
+}
+
 BUILD_DIR=$1
 CACHE_DIR=$2
 
@@ -12,8 +21,6 @@ if [ -e "$BUILD_DIR/.perl-version" ]; then
 else
   PERL_VERSION="5.16.3"
 fi
-
-echo $PERL_VERSION
 
 PERL_PACKAGE="cache.bulknews.net/heroku/perl-$PERL_VERSION.tgz"
 VENDORED_PERL="$BUILD_DIR/vendor/perl"
@@ -25,11 +32,11 @@ export PATH="$BUILD_DIR/local/bin:$VENDORED_PERL/bin:$PATH"
 
 echo "Using perl $PERL_VERSION" | indent
 
-export PERL5LIB="$BUILD_DIR/local/lib/perl5"
-export PERL_CPANM_OPT="--quiet --notest -l $BUILD_DIR/local"
-
 LOCAL_DEPS="$BUILD_DIR/local"
 CACHE_DEPS="$CACHE_DIR/$PERL_VERSION/local"
+
+export PERL5LIB="$LOCAL_DEPS/lib/perl5"
+export PERL_CPANM_OPT="--quiet --notest -l $LOCAL_DEPS"
 
 rm -rf $LOCAL_DEPS
 if [ -d $CACHE_DEPS ]; then
@@ -38,13 +45,11 @@ fi
 
 cd $BUILD_DIR
 
-if ! [ -e $LOCAL_DEPS/bin/cpanm ]; then
-  echo "-----> Bootstrapping cpanm"
-  curl --silent https://raw.github.com/miyagawa/cpanminus/master/cpanm | perl - App::cpanminus 2>&1 | indent
+if ! [ -e $LOCAL_DEPS/bin/carton ]; then
+  echo "-----> Bootstrapping cpanm/Carton"
+  curl --silent https://raw.github.com/miyagawa/cpanminus/master/cpanm | perl - App::cpanminus Carton@0.9.59 2>&1 | indent
+  fixin_shebang
 fi
-
-echo "-----> Installing Carton"
-cpanm --dev Carton 2>&1 | indent
 
 echo "-----> Installing dependencies with Carton"
 carton install --deployment 2>&1 | indent
@@ -52,8 +57,10 @@ carton install --deployment 2>&1 | indent
 echo "-----> Installing Starman"
 cpanm Starman 2>&1 | indent
 
+fixin_shebang
+
 if [ -d "$LOCAL_DEPS" ]; then
   rm -rf "$CACHE_DEPS"
-  mkdir -p "$CACHE_DIR"
+  mkdir -p "$CACHE_DIR/$PERL_VERSION"
   cp -R "$LOCAL_DEPS" "$CACHE_DEPS"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -24,8 +24,11 @@ if ! [ -e $BUILD_DIR/local/bin/cpanm ]; then
   curl --silent https://raw.github.com/miyagawa/cpanminus/master/cpanm | perl - App::cpanminus 2>&1 | indent
 fi
 
-echo "-----> Installing dependencies"
-cpanm --installdeps . 2>&1 | indent
+echo "-----> Installing Carton"
+cpanm --dev Carton
+
+echo "-----> Installing dependencies with Carton"
+carton install --deployment 2>&1 | indent
 
 echo "-----> Installing Starman"
 cpanm Starman 2>&1 | indent

--- a/bin/compile
+++ b/bin/compile
@@ -7,19 +7,38 @@ indent() {
 BUILD_DIR=$1
 CACHE_DIR=$2
 
-PATH="$BUILD_DIR/local/bin:$PATH"
+if [ -e "$BUILD_DIR/.perl-version" ]; then
+  PERL_VERSION=`cat $BUILD_DIR/.perl-version`
+else
+  PERL_VERSION="5.16.3"
+fi
+
+echo $PERL_VERSION
+
+PERL_PACKAGE="cache.bulknews.net/heroku/perl-$PERL_VERSION.tgz"
+VENDORED_PERL="$BUILD_DIR/vendor/perl"
+
+echo "-----> Vendoring Perl"
+mkdir -p $VENDORED_PERL && curl $PERL_PACKAGE -s -o - | tar xzf - -C $VENDORED_PERL
+
+export PATH="$BUILD_DIR/local/bin:$VENDORED_PERL/bin:$PATH"
+
+echo "Using perl $PERL_VERSION" | indent
 
 export PERL5LIB="$BUILD_DIR/local/lib/perl5"
 export PERL_CPANM_OPT="--quiet --notest -l $BUILD_DIR/local"
 
-rm -rf $BUILD_DIR/local
-if [ -d $CACHE_DIR/local ]; then
-  cp -a $CACHE_DIR/local $BUILD_DIR/local
+LOCAL_DEPS="$BUILD_DIR/local"
+CACHE_DEPS="$CACHE_DIR/$PERL_VERSION/local"
+
+rm -rf $LOCAL_DEPS
+if [ -d $CACHE_DEPS ]; then
+  cp -R "$CACHE_DEPS" "$LOCAL_DEPS"
 fi
 
 cd $BUILD_DIR
 
-if ! [ -e $BUILD_DIR/local/bin/cpanm ]; then
+if ! [ -e $LOCAL_DEPS/bin/cpanm ]; then
   echo "-----> Bootstrapping cpanm"
   curl --silent https://raw.github.com/miyagawa/cpanminus/master/cpanm | perl - App::cpanminus 2>&1 | indent
 fi
@@ -33,8 +52,8 @@ carton install --deployment 2>&1 | indent
 echo "-----> Installing Starman"
 cpanm Starman 2>&1 | indent
 
-if [ -d $BUILD_DIR/local ]; then
-  rm -rf $CACHE_DIR/local
-  mkdir -p $CACHE_DIR
-  cp -a $BUILD_DIR/local $CACHE_DIR/local
+if [ -d "$LOCAL_DEPS" ]; then
+  rm -rf "$CACHE_DEPS"
+  mkdir -p "$CACHE_DIR"
+  cp -R "$LOCAL_DEPS" "$CACHE_DEPS"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -45,6 +45,7 @@ fi
 
 cd $BUILD_DIR
 
+# TODO pre-build extras for each perl to speed up
 if ! [ -e $LOCAL_DEPS/bin/carton ]; then
   echo "-----> Bootstrapping cpanm/Carton"
   curl --silent https://raw.github.com/miyagawa/cpanminus/master/cpanm | perl - App::cpanminus Carton@0.9.59 2>&1 | indent
@@ -54,6 +55,7 @@ fi
 echo "-----> Installing dependencies with Carton"
 carton install --deployment 2>&1 | indent
 
+# TODO support different server type via Procfile
 echo "-----> Installing Starman"
 cpanm Starman 2>&1 | indent
 

--- a/bin/release
+++ b/bin/release
@@ -6,5 +6,5 @@ addons:
 config_vars:
   PATH: local/bin:/usr/local/bin:/usr/bin:/bin
 default_process_types:
-  web: perl -Mlib=\$PWD/local/lib/perl5 ./local/bin/starman --preload-app --port \$PORT
+  web: carton exec starman --preload-app --port \$PORT
 EOF

--- a/bin/release
+++ b/bin/release
@@ -5,7 +5,7 @@ cat << EOF
 addons:
 config_vars:
   PATH: /app/local/bin:/app/vendor/perl/bin:/usr/local/bin:/usr/bin:/bin
-  PERL5LIB: local/lib/perl5
+  PERL5LIB: /app/local/lib/perl5
 default_process_types:
   web: carton exec starman --preload-app --port \$PORT
 EOF

--- a/bin/release
+++ b/bin/release
@@ -4,7 +4,7 @@ cat << EOF
 ---
 addons:
 config_vars:
-  PATH: local/bin:/usr/local/bin:/usr/bin:/bin
+  PATH: /app/local/bin:/app/vendor/perl/bin:/usr/local/bin:/usr/bin:/bin
   PERL5LIB: local/lib/perl5
 default_process_types:
   web: carton exec starman --preload-app --port \$PORT

--- a/bin/release
+++ b/bin/release
@@ -5,6 +5,7 @@ cat << EOF
 addons:
 config_vars:
   PATH: local/bin:/usr/local/bin:/usr/bin:/bin
+  PERL5LIB: local/lib/perl5
 default_process_types:
   web: carton exec starman --preload-app --port \$PORT
 EOF

--- a/support/build_perl
+++ b/support/build_perl
@@ -3,7 +3,7 @@ PERL_VERSION="$1"
 
 cat <<EOF
 git clone git://github.com/tokuhirom/Perl-Build.git /tmp/perl-build
-/tmp/perl-build/perl-build -Duserelocatableinc $PERL_VERSION /tmp/perl/$PERL_VERSION
+/tmp/perl-build/perl-build -Duserelocatableinc -j 8 $PERL_VERSION /tmp/perl/$PERL_VERSION
 
 tar -czf perl-$PERL_VERSION.tgz -C /tmp/perl/$PERL_VERSION .
 EOF

--- a/support/build_perl
+++ b/support/build_perl
@@ -1,0 +1,9 @@
+#!/bin/bash
+PERL_VERSION="$1"
+
+cat <<EOF
+git clone git://github.com/tokuhirom/Perl-Build.git /tmp/perl-build
+/tmp/perl-build/perl-build -Duserelocatableinc $PERL_VERSION /tmp/perl/$PERL_VERSION
+
+tar -czf perl-$PERL_VERSION.tgz -C /tmp/perl/$PERL_VERSION .
+EOF


### PR DESCRIPTION
This change requires apps to freeze app dependencies with carton (and check in `carton.lock` in the git repo), then release a web app that uses `carton exec` to run starman.
