### PR TITLE
Adding default PERL5LIB to support custom Procfile entries

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -5,6 +5,7 @@ cat << EOF
 addons:
 config_vars:
   PATH: local/bin:/usr/local/bin:/usr/bin:/bin
+  PERL5LIB: local/lib/perl5
 default_process_types:
   web: perl -Mlib=\$PWD/local/lib/perl5 ./local/bin/starman --preload-app --port \$PORT
 EOF


### PR DESCRIPTION
In the default process type we are setting -Mlib to include `local/lib/perl5`. However, if a custom Procfile is specified, the modules can't be located. This adds `local/lib/perl5` to the process environment which is a safer bet.
