### PR TITLE
update raw URL to raw.githubusercontent.com

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -21,7 +21,7 @@ cd $BUILD_DIR
 
 if ! [ -e $BUILD_DIR/local/bin/cpanm ]; then
   echo "-----> Bootstrapping cpanm"
-  curl -L --silent https://raw.github.com/miyagawa/cpanminus/master/cpanm | perl - App::cpanminus 2>&1 | indent
+  curl -L --silent https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm | perl - App::cpanminus 2>&1 | indent
 fi
 
 echo "-----> Installing dependencies"


### PR DESCRIPTION
Github has recently switched over from https://raw.github.com to https://raw.githubusercontent.com for hosting raw URLs. If you go to https://raw.github.com/miyagawa/cpanminus/master/cpanm, you will be redirected to https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm.
